### PR TITLE
HotFix: Correction of undefined data in NextJS configurations.

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,7 @@ const withNextIntl = createNextIntlPlugin();
 const isDev = process.env.NODE_ENV === 'development';
 
 const nextConfig = {
-    output: isDev ? undefined : 'export',
+    output: isDev ? 'standalone' : 'export',
     eslint: {
         ignoreDuringBuilds: true,
     },

--- a/src/app/redes/layout.tsx
+++ b/src/app/redes/layout.tsx
@@ -1,0 +1,11 @@
+import {ReactNode} from 'react';
+
+type Props = {
+    children: ReactNode;
+};
+
+// Since we have a `not-found.tsx` page on the root, a layout file
+// is required, even if it's just passing children through.
+export default function RootLayout({children}: Props) {
+    return children;
+}

--- a/src/app/redes/not-found.tsx
+++ b/src/app/redes/not-found.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Error from 'next/error';
+
+// This page renders when a route like `/unknown.txt` is requested.
+// In this case, the layout at `app/[locale]/layout.tsx` receives
+// an invalid value as the `[locale]` param and calls `notFound()`.
+
+export default function GlobalNotFound() {
+    return (
+        <html lang="en">
+        <body>
+        <Error statusCode={404}/>;
+        </body>
+        </html>
+    );
+}

--- a/src/app/redes/page.tsx
+++ b/src/app/redes/page.tsx
@@ -1,0 +1,6 @@
+import {permanentRedirect, redirect} from 'next/navigation';
+
+// This page only renders when the app is built statically (output: 'export')
+export default function RootPage() {
+    permanentRedirect('/en/redes');
+}


### PR DESCRIPTION
Correction of undefined data in NextJS configurations and the permanent redirection of the "/redes" route to "/en/redes" was added so that SEO is not affected and the previously used links are not invalidated.